### PR TITLE
Add high z-index to sr-reader class

### DIFF
--- a/jetzt.css
+++ b/jetzt.css
@@ -24,6 +24,7 @@
 
 
 .sr-reader {
+  z-index: 999999;
   position: fixed;
   top: -50%;
   left: 50%;


### PR DESCRIPTION
On Medium pages (e.g. https://medium.com/on-coding/5fc3f7d5510d?ref=heydesigner) the reader modal is displayed under the content.

![screenshot - 03062014 - 09 56 50 am](https://f.cloud.github.com/assets/2248534/2343354/61289e40-a50d-11e3-9e54-ec94e8d967d3.png)

This make the reading particularly difficult.

As a solution I've added an high z-index (i.e. 9999999) to the class associated with the modal (i.e. sr-reader).

P.S: please forgive me if my modification may break something or/and if the description of the problem isn't specific enough. Don't hesitate to contact if these are the case.
