### PR TITLE
Dark theme for jetzt speedreader

### DIFF
--- a/jetzt.css
+++ b/jetzt.css
@@ -76,6 +76,11 @@
   line-height: 60px;
 }
 
+.sr-reader.sr-dark > .sr-wrap {
+  color: white;
+  background-color: #555;
+}
+
 .sr-reader .sr-wrap.sr-left {
   border-top-left-radius: 8px;
   border-bottom-left-radius: 8px;
@@ -91,6 +96,10 @@
   width: 400px;
   background: white;
   position: relative;
+}
+
+.sr-reader.sr-dark .sr-word-box {
+  background-color: black;
 }
 
 .sr-reader .sr-word-box .sr-progress {
@@ -129,6 +138,11 @@
   box-sizing: border-box;
 }
 
+.sr-reader.sr-dark .sr-word-box .sr-wpm {
+  color: white;
+  background-color: black;
+}
+
 .sr-reader .sr-word-box .sr-word {
   position: absolute;
   top: 50%;
@@ -143,8 +157,16 @@
   color: black;
 }
 
+.sr-reader.sr-dark .sr-word-box .sr-word > span {
+  color: white;
+}
+
 .sr-reader .sr-word-box .sr-word .sr-pivot {
   color: red;
+}
+
+.sr-reader.sr-dark .sr-word-box .sr-word .sr-pivot {
+  color: #00ff00;
 }
 
 .sr-highlight {

--- a/jetzt.js
+++ b/jetzt.js
@@ -284,7 +284,7 @@
     $$  __$$\ $$  __$$\ $$  __$$\ $$  __$$\ \_$$  _|$$$\  $$ |$$  __$$\
     $$ |  $$ |$$ /  $$ |$$ |  $$ |$$ /  \__|  $$ |  $$$$\ $$ |$$ /  \__|
     $$$$$$$  |$$$$$$$$ |$$$$$$$  |\$$$$$$\    $$ |  $$ $$\$$ |$$ |$$$$\
-    $$  ____/ $$  __$$ |$$  __$$<  \____$$\   $$ |  $$ \$$$$ |$$ |\_$$ |
+    $$  ____/ $$  __$$ |$$  __$$   \____$$\   $$ |  $$ \$$$$ |$$ |\_$$ |
     $$ |      $$ |  $$ |$$ |  $$ |$$\   $$ |  $$ |  $$ |\$$$ |$$ |  $$ |
     $$ |      $$ |  $$ |$$ |  $$ |\$$$$$$  |$$$$$$\ $$ | \$$ |\$$$$$$  |
     \__|      \__|  \__|\__|  \__| \______/ \______|\__|  \__| \______/
@@ -610,6 +610,9 @@
       this.setScale(config("scale"));
       this.setWPM(config("target_wpm"));
 
+      // initialise custom theme
+      this.setTheme(config("dark"));
+
       grabFocus();
       hiddenInput.onblur = grabFocus;
 
@@ -637,6 +640,13 @@
 
     this.setWPM = function (target_wpm) {
       wpm.innerHTML = target_wpm + "";
+    };
+
+    this.setTheme = function (dark) {
+      if (dark)
+        addClass(box, "sr-dark");
+      else
+        removeClass(box, "sr-dark");
     };
 
     this.setProgress = function (percent) {
@@ -835,6 +845,14 @@
     reader && reader.setWPM(adjusted);
   };
 
+  /**
+   * Toggle the theme of the reader
+   */
+  function toggleTheme () {
+    var current = config("dark");
+    config("dark", !current);
+    reader && reader.setTheme(config("dark"));
+  };
 
   function handleKeydown (ev) {
     var killEvent = function () {
@@ -878,6 +896,10 @@
       case 189: //minus
         killEvent();
         adjustScale(-0.1);
+        break;
+      case 48: //0 key, for changing the theme
+        killEvent();
+        toggleTheme();
         break;
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ I also welcome pull requests of all shapes and sizes. This project is still in h
 - [h0ru5](http://github.com/h0ru5)
 - [fusillicode](http://github.com/fusillicode)
 - [Brian Hanson](http://github.com/brianjhanson)
+- [ianzapolsky](http://github.com/ianzapolsky)
 
 
 ### License


### PR DESCRIPTION
Added a dark theme for jetzt, taking into account comments from ds300. Trying
to stay truer to the control methods have already been written. Changed the
way the CSS is implemented, to instead add the sr-dark class to the sr-reader
element.
