### PR TITLE
Add usable bookmarklet link to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,12 @@ Control is currently keyboard-only.
 ### Bookmarklet
 
 You can also use it as a bookmarklet by:
+
 - Copying the content of bookmarklet.js
 - Manually adding a new bookmark
-- Pasting the content into the location field. 
+- Pasting the content into the location field.
+
+Or by dragging this link to your bookmarks toolbar: [Jetzt](javascript:(function(){var addStyle=function(url){var style=document.createElement("link");style.rel="stylesheet";style.type="text/css";style.href=url;document.head.appendChild(style)};var addScript=function(url,cb){var script=document.createElement("script");script.src=url;if(cb){script.onload=cb}document.body.appendChild(script)};if(typeof window.jetzt==="undefined"){var cb=function(){addScript("https://rawgithub.com/ds300/jetzt/master/localstorage-config.js");window.jetzt.select()};addStyle("https://rawgithub.com/ds300/jetzt/master/jetzt.css");addScript("https://raw.github.com/ds300/jetzt/master/jetzt.js",cb)}else{window.jetzt.select()}})();).
 
 ### ToDo
 


### PR DESCRIPTION
This pull request adds a usable bookmarklet link to `readme.md`, so that users can drag and drop the link onto their bookmarks toolbar, or copy and past the link into their bookmarks manager.

This feature may close issue #56.

I license this contribution under the Apache License 2.0.
