### PR TITLE
Add a duration remaining message toggle

### DIFF
--- a/jetzt.js
+++ b/jetzt.js
@@ -932,6 +932,22 @@
     reader && reader.setTheme(config("dark"));
   };
 
+  /**
+   * Toggle present status
+   * During reading: show number of seconds left to completion
+   * After reading: show number of words and seconds elapsed
+   */
+  function toggleStatus () {
+    if (running) {
+      var words = instructions.length;
+      var timestamp = Math.round(new Date().getTime() / 1000);
+      var elapsed = timestamp - reader.started;
+      var remaining = (elapsed * (words - index)) / index;
+      reader.setMessage(Math.round(remaining) + "s left”);
+    }
+    reader && reader.toggleMessage();
+  }
+
   function handleKeydown (ev) {
     if(ev.ctrlKey || ev.metaKey) {
     	return;
@@ -986,7 +1002,7 @@
         break;
       case 191: // / and ?
         killEvent();
-        reader && reader.toggleMessage();
+        toggleStatus();
         break;
     }
   }


### PR DESCRIPTION
This pull request adds the ability to toggle a message displaying the approximate time remaining in seconds till reading is completed.

This message is shown using the same DOM element and interface command (the / or ? key) as introduced in pull request #62.

This is how this feature looks:

![duration-remaining](https://f.cloud.github.com/assets/23469/2431177/fc6ae966-ad1f-11e3-9cbe-f7af9753b62b.png)

Possible feature upgrades include showing minutes and seconds if the number of seconds exceeds 60s, and automatic updating of the remaining time per second for as long as the message display is open.

This pull request is intended to close issue #25.

This contribution is licensed under the Apache License 2.0.
