### PR TITLE
Load the options from the default config backend

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -253,6 +253,9 @@
     var numThemes = options.themes.length;
     this("selected_theme", (current + 1) % numThemes);
   };
+  
+  // load the options from the default config backend
+  jetzt.config.setBackend(configBackend);
 
 })(this);
 


### PR DESCRIPTION
Previously the config from the default configBackend was never
retrieved on creation, making it useless for bookmarklet and demo.
