### PR TITLE
Added some domain-specific DOM parsing in the selection step

### DIFF
--- a/modules/select.js
+++ b/modules/select.js
@@ -100,6 +100,46 @@
       }
     };
 
+    var domainSpecificDomModifications = function(selection) {
+      if (location.host === "play.google.com" &&
+          location.href.indexOf('com/books/reader') != -1) {
+        return modifyDomForGooglePlay(selection);
+      }
+      return selection;
+    };
+
+    var modifyDomForGooglePlay = function(selection) {
+      console.log(selection);
+      var newSelection = []
+      for (var i = 0; i < selection.length; i++) {
+        var text = getTextFromGbsChildren(selection[i]);
+        var p = document.createElement("P");
+        p.appendChild(document.createTextNode(text));
+        newSelection.push(p);
+      }
+      return newSelection;
+    }
+
+    var getTextFromGbsChildren = function(element) {
+      var text = "";
+      for (var i = 0; i < element.childNodes.length; i++) {
+        var child = element.childNodes[i];
+        if (child.tagName === 'GBS') {
+          for (var j = 0; j < child.childNodes.length; j++) {
+            var textNode = child.childNodes[j];
+            if (textNode.tagName === 'GBT') {
+              if (window.getComputedStyle(textNode).display !== 'none') {
+                text += textNode.textContent;
+              }
+            }
+          }
+        } else {
+          text += getTextFromGbsChildren(child);
+        }
+      }
+      return text;
+    }
+
     var stop = function () {
       jetzt.view.removeAllOverlays();
       off("mouseover", mouseoverHandler);
@@ -126,6 +166,7 @@
 
     var clickHandler = function (ev) {
       stop();
+      selection = domainSpecificDomModifications(selection);
       jetzt.init(jetzt.parse.dom(selection));
     };
 


### PR DESCRIPTION
A start to fixing issue #79.  This introduces a DOM-modification step in between selection and parsing, so that if there are any changes that need to be made to bypass obfuscation, they can happen here.  This works for me for Google Play Books (only needed if the book has been purchased - uploaded books don't have the obfuscation).  A similar approach should also work for the Kindle Cloud Reader, though I don't have books there that I want to read, so I probably won't work on that part.
