### PR TITLE
option for striping citations

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -72,6 +72,7 @@
     dark: false,
     selected_theme: 0,
     show_message: false,
+    strip_citation: false,
     selection_color: "#FF0000",
     modifiers: DEFAULT_MODIFIERS,
     font_family: "Menlo, Monaco, Consolas, monospace",

--- a/modules/parse.js
+++ b/modules/parse.js
@@ -52,6 +52,34 @@
     return result;
   }
 
+  // regexp that matches in-text citations
+  var _reInTextCitation = (function () {
+    var au = "((\\S\\.\\s)?(\\S+\\s)?\\S+?)";          // author
+    var et = "(,?\\set\\sal\\.?)";                     // et al.
+
+    var yr = "((16|17|18|19|20)\\d{2}[a-z]?)";         // year restricted in 17c.-21c.
+    var pt = "([a-z]{1,4}\\.\\s\\d+)";                 // part: p. 199, chap. 5, etc.
+    var yp = "(" + yr + "|" + pt + ")";                // year and part
+    var pp = "(" + pt + "|\\d+)";                      // part and page
+
+    var as = "((" + au + ",\\s)*" + au +
+             ",?\\s(and|&)\\s)?" + au + et;            // multiple authors
+    var ml = as + "?\\s\\d+(,\\s\\d+)*";               // MLA author-page (disabled)
+    var ap = "(" + as + "?,?\\s)?" + yp +
+             "((,\\s|:)" + pp + ")*";                  // APA/CMS/ASA author-year-page
+
+    var hs = "(" + as + "|" + ap + ")";                // humanist single citation
+    var hm = "\\((" + hs + "(;|,|,?\\s(and|&))\\s)*" +
+             hs + "\\)";                               // humanist multiple citations
+    var ie = "\\[\\d+\\]";                             // IEEE
+
+    return new RegExp("\\s?(" + hm + "|" + ie + ")", "g");
+  })();
+
+  function stripInTextCitation (text) {
+    return text.replace(_reInTextCitation, "");
+  }
+
   /**
    * Helper class for generating jetzt instructions.
    * Very subject to change.
@@ -226,8 +254,10 @@
 
   // convert raw text into instructions
   function parseText (text,$instructionator) {
+    if (config("strip_citation")) text = stripInTextCitation(text);
                         // long dashes ↓
     var tokens = text.match(/["«»“”\(\)\/–—]|--+|\n+|[^\s"“«»”\(\)\/–—]+/g);
+    if (tokens === null) tokens = [];
 
     var $ = ($instructionator) ? $instructionator :  new Instructionator();
 

--- a/options/scripts/options-ng.js
+++ b/options/scripts/options-ng.js
@@ -51,6 +51,7 @@ optsApp.controller("ReadingCtrl", function ($scope, $window, jetzt, Persist) {
 	// make sure we get the versions from storage
 	jetzt.config.refresh(function () {
 		$scope.modifiers = angular.copy(jetzt.config("modifiers"));
+		$scope.stripCitation = jetzt.config("strip_citation");
 		saved = angular.copy(jetzt.config("modifiers"));
 		$scope.$$phase || $scope.$apply();
 	});
@@ -80,6 +81,7 @@ optsApp.controller("ReadingCtrl", function ($scope, $window, jetzt, Persist) {
 
 	Persist($scope, function () {
 		jetzt.config("modifiers", $scope.modifiers);
+		jetzt.config("strip_citation", $scope.stripCitation);
 	});
 });
 

--- a/options/templates/reading.html
+++ b/options/templates/reading.html
@@ -1,5 +1,5 @@
 <section>
-	<p>Duration modifiers</p>
+	<h3>Duration modifiers</h3>
 
 	<aside id="spacing-demo">
 		<p>...occaecat cupidatat non <span class="end_clause">proident,</span> <span class="start_clause">sunt</span> in culpa qui officia deserunt mollit anim id est <span class="end_paragraph">laborum.</span></p>
@@ -15,4 +15,8 @@
 	<br />
 	<button ng-click="resetSessionModifiers()" ng-disabled="isSessionClean()">Reset</button>
 	<button ng-click="resetDefaultModifiers()" ng-disabled="isClean()">Reset to Defaults</button>
+	<br />
+	<br />
+	<h3>Text preparation</h3>
+	<p>Strip in-text citations: <input type="checkbox" ng-model="stripCitation"/></p>
 </section>


### PR DESCRIPTION
- Use regex to match a usual subset of APA, CMS, ASA, and IEEE in-text
citation styles, which cover a substantial majority of citations on
ScienceDirect.com, Wikipedia.org and other academic sites.
- The regex tries to keep high precisions and moderate recalls. MLA in-text citation isn't supported due to its low precision.
- The functionality can be toggled using ```"strip_citation"``` config term, the default is set to ```false```. A switch is provided in the options page.