### PR TITLE
include the hotkeys list

### DIFF
--- a/options/templates/keyboard.html
+++ b/options/templates/keyboard.html
@@ -1,3 +1,12 @@
 <section>
-	TODO
+<ul>
+<li><p>Initiate jetzt by pressing <code>alt</code>-<code>s</code> and clicking on the block of text you wish to read. Alternatively, select some text before pressing <code>alt</code>-<code>s</code>.</p></li>
+<li><p>Change size with <code>+</code>/<code>-</code>.</p></li>
+<li><p>Go faster/slower with up/down arrow keys.</p></li>
+<li><p>Go back/forward a sentence with left/right arrow keys (hold <code>alt</code> to navigate by paragraphs).</p></li>
+<li><p>Pause with space.</p></li>
+<li><p>Close with escape.</p></li>
+<li><p>Switch between light/dark themes with <code>0</code></p></li>
+<li><p>Toggle summary stats with <code>/</code> or <code>?</code> at the end of a run</p></li>
+</ul>
 </section>


### PR DESCRIPTION
Any time I install jetzt on a new computer I've had to go to the website to recall how to switch to dark theme.... so why not include the hotkeys list here?