### PR TITLE
Fix Ubuntu font CSS URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>jetzt - a Speed Reader Extension for Chrome</title>
-<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Ubuntu:300,500">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Ubuntu:300,500">
 <link rel="icon" href="favicon.ico">
 <style>
 html {


### PR DESCRIPTION
The link was pointing to the `http` version of the font at:

http://fonts.googleapis.com/css?family=Ubuntu:300,500

But the site is being served from an HTTPS link at:

https://ds300.github.io/jetzt/

Some browsers were refusing to load the http link from the https site.

So change the first link above to load from https.